### PR TITLE
Migrate to new sendsafely module

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 plac_ini
-https://github.com/SendSafely/Python-Client-API/releases/download/v1.0.0/SendSafely-Python-API-1.0.0.tar.gz
+sendsafely

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
                        ],
     install_requires = [
                          "plac_ini",
-                         "SendSafely-Python-API",
+                         "sendsafely",
                        ],
     entry_points     = {
                          'console_scripts': [


### PR DESCRIPTION
`SendSafely-Python-API` module is now simply `sendsafely`